### PR TITLE
feat: Open PacketHelper API

### DIFF
--- a/ph/main.py
+++ b/ph/main.py
@@ -30,13 +30,13 @@ templates = Jinja2Templates(directory="static")
 
 
 @app.get("/", include_in_schema=False)
-def get_root(request: Request, status_code=status.HTTP_200_OK):
+def get_root(request: Request, status_code=status.HTTP_200_OK) -> HTMLResponse:
     """Return Vue singlepage"""
     return templates.TemplateResponse("index.html", {"request": request})
 
 
 @app.get("/hex/{hex_string}", include_in_schema=False)
-def get_hex(request: Request, status_code=status.HTTP_200_OK):
+def get_hex(request: Request, status_code=status.HTTP_200_OK) -> HTMLResponse:
     """Return specific path for Vue singlepage"""
     return templates.TemplateResponse("index.html", {"request": request})
 

--- a/ph/main.py
+++ b/ph/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Request, status
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -15,6 +16,13 @@ app = FastAPI(
         "url": "https://github.com/PacketHelper/packet-helper-next/blob/main/LICENSE",
     },
 )
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.include_router(api, prefix="/api", tags=["api"])
 
@@ -22,13 +30,13 @@ templates = Jinja2Templates(directory="static")
 
 
 @app.get("/", include_in_schema=False)
-def get_root(request: Request, status_code=status.HTTP_200_OK) -> HTMLResponse:
+def get_root(request: Request, status_code=status.HTTP_200_OK):
     """Return Vue singlepage"""
     return templates.TemplateResponse("index.html", {"request": request})
 
 
 @app.get("/hex/{hex_string}", include_in_schema=False)
-def get_hex(request: Request, status_code=status.HTTP_200_OK) -> HTMLResponse:
+def get_hex(request: Request, status_code=status.HTTP_200_OK):
     """Return specific path for Vue singlepage"""
     return templates.TemplateResponse("index.html", {"request": request})
 


### PR DESCRIPTION
Enable PacketHelper for all. Now you're able to use API endpoint for your purpose -- no need to install wireshark, tshark & pyshark on each machine. 

For more information about endpoints, go to swagger https://www.packethelper.com/docs 