### PR TITLE
fix: Remove information about legacy version and fix typo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,13 +6,6 @@
         <!-- Provides the application the proper gutter -->
         <v-container fluid>
           <v-container>
-            <v-alert icon="mdi-shield-lock-outline" prominent text type="info">
-              <strong>Legacy version</strong> of the PacketHelper is available
-              at
-              <a href="http://legacy.packethelper.com"
-                >http://legacy.packethelper.com
-              </a>
-            </v-alert>
             <!-- If using vue-router -->
             <transition name="route" mode="out-in">
               <router-view> </router-view>

--- a/src/interfaces/packet.ts
+++ b/src/interfaces/packet.ts
@@ -18,6 +18,6 @@ export interface Structure {
   repr: string;
   repr_full: string;
   tshark_name: string;
-  tshart_raw_summary: string[];
+  tshark_raw_summary: string[];
   chksum_status: StructureChksumStatus;
 }


### PR DESCRIPTION
Before:
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/18559953/197502088-11fedb57-94e0-4c4f-9798-7bfc95d39491.png">
